### PR TITLE
fix: fix sql generation for json.RawMessage

### DIFF
--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -2,6 +2,7 @@ package sqlgen
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"reflect"
 	"strconv"
 	"time"
@@ -136,6 +137,8 @@ func (esg *expressionSQLGenerator) reflectSQL(b sb.SQLBuilder, val interface{}) 
 	case util.IsSlice(valKind):
 		switch t := val.(type) {
 		case []byte:
+			esg.literalBytes(b, t)
+		case json.RawMessage:
 			esg.literalBytes(b, t)
 		case []exp.CommonTableExpression:
 			esg.commonTablesSliceSQL(b, t)

--- a/sqlgen/expression_sql_generator_test.go
+++ b/sqlgen/expression_sql_generator_test.go
@@ -2,6 +2,7 @@ package sqlgen_test
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
@@ -221,6 +222,12 @@ func (esgs *expressionSQLGeneratorSuite) TestGenerate_BytesTypes() {
 
 		expressionTestCase{val: []byte("Hello'"), sql: "'Hello'''"},
 		expressionTestCase{val: []byte("Hello'"), sql: "?", isPrepared: true, args: []interface{}{[]byte("Hello'")}},
+
+		expressionTestCase{val: json.RawMessage("Hello"), sql: "'Hello'"},
+		expressionTestCase{val: json.RawMessage("Hello"), sql: "?", isPrepared: true, args: []interface{}{[]byte("Hello")}},
+
+		expressionTestCase{val: json.RawMessage("Hello'"), sql: "'Hello'''"},
+		expressionTestCase{val: json.RawMessage("Hello'"), sql: "?", isPrepared: true, args: []interface{}{[]byte("Hello'")}},
 	)
 }
 


### PR DESCRIPTION
Fixes an issue where SQL for json.RawMessage-expressions is not generated correctly (as it is with byte slices).

Closes #350